### PR TITLE
Support for today's web.whatsapp.com

### DIFF
--- a/js/whatsapp.js
+++ b/js/whatsapp.js
@@ -6,10 +6,18 @@ function simulateMouseEvents(element, eventName) {
 
 var selectConversation = function() {
   return new Promise(function(resolve, reject) {
-    var conversation = jQuery('[title^="' + conversation_title + '"]')[0];
-    conversation.click();
-    simulateMouseEvents( conversation , 'mousedown');
-    resolve();
+    if ( conversation_title == '/' || conversation_title == '' ) {
+      resolve();
+    }
+    else {
+      // also checking .ellipsify as Group Members will also be shown with title attribute
+      var $conversation = jQuery('.ellipsify[title^="' + conversation_title + '"]');
+      // fallback to "any substring" if a conversation starting with the arg is not found
+      var conversation = $conversation.length ? $conversation[0] : jQuery('.ellipsify[title*="' + conversation_title + '"]')[0];
+      conversation.click();
+      simulateMouseEvents( conversation , 'mousedown');
+      resolve();
+    }
   });
 };
 

--- a/js/whatsapp.js
+++ b/js/whatsapp.js
@@ -1,29 +1,30 @@
-var dispatch = function(target, eventType, char) {
-    var evt = document.createEvent('TextEvent');
-    evt.initTextEvent (eventType, true, true, window, char, 0, 'en-US');
-    target.focus();
-    target.dispatchEvent(evt);
-};
+function simulateMouseEvents(element, eventName) {
+    var mouseEvent= document.createEvent('MouseEvents');
+    mouseEvent.initEvent(eventName, true, true);
+    element.dispatchEvent(mouseEvent);
+}
 
 var selectConversation = function() {
   return new Promise(function(resolve, reject) {
-    var conversation = document.querySelector('[title="' + conversation_title + '"]');
+    var conversation = jQuery('[title^="' + conversation_title + '"]')[0];
     conversation.click();
+    simulateMouseEvents( conversation , 'mousedown');
     resolve();
   });
 };
 
 var insertMessage = function() {
   return new Promise(function(resolve, reject) {
-    var textInput = document.querySelector('div.input');
-    dispatch(textInput, 'textInput', message);
+    var $element = jQuery("div.pluggable-input-body").text(message);
+    const event = new Event('input', { bubbles: true })
+    $element[0].dispatchEvent(event)
     resolve();
   });
 };
 
 var sendMessage = function() {
   return new Promise(function(resolve, reject) {
-    var sendButton = document.querySelector('button.send-container');
+    var sendButton = document.querySelector('button.compose-btn-send');
     sendButton.click();
     resolve();
   });

--- a/whatsapp.scpt
+++ b/whatsapp.scpt
@@ -39,7 +39,13 @@ on run(arguments)
 	close access whatsapp_file
 
 	set conversation_title to first item of arguments
-	set message to second item of arguments
+
+    set rest_arguments to {}
+    repeat with i from 2 to length of arguments
+        copy item i of arguments to the end of rest_arguments
+    end repeat
+    set AppleScript's text item delimiters to space
+	set message to rest_arguments as string
 
 	set browsers to {"Google Chrome", "Google Chrome Canary"}
 	repeat with browser in browsers


### PR DESCRIPTION
Sorry for a lot of changes and different indentation (I mostly use 4 spaces)

This contains the following features:

1. Work as in README.md : `osascript whatsapp.scpt "First Last" "Message"`
2. No need to quote the whole message: `osascript whatsapp.scpt "First Last" How are you today?`
3. Support for partial starting contact name (message only sent to first match): `osascript whatsapp.scpt First How are you?`
4. Support for substring of contact name, if the "starting" doesn't find any results: `osascript whatsapp.scpt Last Hey Mr. Last. Good Morning!`
5. Support for using `/` or `''` for current chat (so multiple messages are easier when we don't have to switch chats): `osascript whatsapp.scpt '' Good Morning!` `osascript whatsapp.scpt / I am fine!` (Implemented the `/` as that is 1 keystroke less than `''` 😛 )

If @victor-torres doesn't like any of the above, please kindly merge the PR and do changes afterwards! 🙏 