### PR TITLE
Read 5 most recent messages with empty message

### DIFF
--- a/js/whatsapp.js
+++ b/js/whatsapp.js
@@ -11,9 +11,9 @@ var selectConversation = function() {
     }
     else {
       // also checking .ellipsify as Group Members will also be shown with title attribute
-      var $conversation = jQuery('.ellipsify[title^="' + conversation_title + '"]');
+      var $conversation = jQuery('[dir=auto][title^="' + conversation_title + '"]');
       // fallback to "any substring" if a conversation starting with the arg is not found
-      var conversation = $conversation.length ? $conversation[0] : jQuery('.ellipsify[title*="' + conversation_title + '"]')[0];
+      var conversation = $conversation.length ? $conversation[0] : jQuery('[dir=auto][title*="' + conversation_title + '"]')[0];
       conversation.click();
       simulateMouseEvents( conversation , 'mousedown');
       resolve();
@@ -23,7 +23,7 @@ var selectConversation = function() {
 
 var insertMessage = function() {
   return new Promise(function(resolve, reject) {
-    var $element = jQuery("div.pluggable-input-body").text(message);
+    var $element = jQuery("div.copyable-text.selectable-text").text(message);
     const event = new Event('input', { bubbles: true })
     $element[0].dispatchEvent(event)
     resolve();
@@ -32,7 +32,7 @@ var insertMessage = function() {
 
 var sendMessage = function() {
   return new Promise(function(resolve, reject) {
-    var sendButton = document.querySelector('button.compose-btn-send');
+    var sendButton = $("[data-icon=send]").parent();
     sendButton.click();
     resolve();
   });

--- a/js/whatsapp.js
+++ b/js/whatsapp.js
@@ -39,7 +39,17 @@ var sendMessage = function() {
 };
 
 selectConversation().then(function() {
-  insertMessage().then(function() {
-    sendMessage().then(function() {});
-  });
+  if( $.trim(message) != '' ) {
+    msgs = '';
+    insertMessage().then(function() {
+      sendMessage().then(function() {});
+    });
+  }
+  else {
+    msgs = jQuery("[data-pre-plain-text]").slice(-5)
+             .toArray().map( function(j) {
+               return j.dataset.prePlainText +
+                 j.innerText.replace( /\d+:\d+\n/, '' )
+             }).join('');
+  }
 });

--- a/whatsapp.scpt
+++ b/whatsapp.scpt
@@ -1,56 +1,56 @@
 on is_running(app_name)
-    tell application "System Events" to (name of processes) contains app_name
+  tell application "System Events" to (name of processes) contains app_name
 end is_running
 
 on execute_javascript(browser, jquery, whatsapp, conversation_title, message)
-	using terms from application "Google Chrome"
-		set app_is_running to is_running(browser)
-		if not app_is_running then
-			return
-		end if
+  using terms from application "Google Chrome"
+    set app_is_running to is_running(browser)
+    if not app_is_running then
+      return
+    end if
 
-		tell application browser
-			repeat with w in windows
-				repeat with t in tabs of w
-					if URL of t starts with "https://web.whatsapp.com/" then
-						execute t javascript ("var conversation_title = \"" & conversation_title & "\";")
-						execute t javascript ("var message = \"" & message & "\";")
-						execute t javascript jquery
-						execute t javascript whatsapp
-                        set msgs to execute t javascript "msgs" 
-                        if msgs is not "" then return msgs
-					end if
-				end repeat
-			end repeat
-		end tell
-	end using terms from
+    tell application browser
+      repeat with w in windows
+        repeat with t in tabs of w
+          if URL of t starts with "https://web.whatsapp.com/" then
+            execute t javascript ("var conversation_title = \"" & conversation_title & "\";")
+            execute t javascript ("var message = \"" & message & "\";")
+            execute t javascript jquery
+            execute t javascript whatsapp
+            set msgs to execute t javascript "msgs"
+            if msgs is not "" then return msgs
+          end if
+        end repeat
+      end repeat
+    end tell
+  end using terms from
 end execute_javascript
 
 on run(arguments)
-	set javascript_folder to POSIX path of ((the path to me as text) & "::")
-	set jquery_file to (POSIX file (javascript_folder & "js/jquery.min.js"))
-	set whatsapp_file to (POSIX file (javascript_folder & "js/whatsapp.js"))
+  set javascript_folder to POSIX path of ((the path to me as text) & "::")
+  set jquery_file to (POSIX file (javascript_folder & "js/jquery.min.js"))
+  set whatsapp_file to (POSIX file (javascript_folder & "js/whatsapp.js"))
 
-	open for access jquery_file
-	set jquery to (read jquery_file)
-	close access jquery_file
+  open for access jquery_file
+  set jquery to (read jquery_file)
+  close access jquery_file
 
-	open for access whatsapp_file
-	set whatsapp to (read whatsapp_file)
-	close access whatsapp_file
+  open for access whatsapp_file
+  set whatsapp to (read whatsapp_file)
+  close access whatsapp_file
 
-	set conversation_title to first item of arguments
+  set conversation_title to first item of arguments
 
-    set rest_arguments to {}
-    repeat with i from 2 to length of arguments
-        copy item i of arguments to the end of rest_arguments
-    end repeat
-    set AppleScript's text item delimiters to space
-	set message to rest_arguments as string
+  set rest_arguments to {}
+  repeat with i from 2 to length of arguments
+    copy item i of arguments to the end of rest_arguments
+  end repeat
+  set AppleScript's text item delimiters to space
+  set message to rest_arguments as string
 
-	set browsers to {"Google Chrome", "Google Chrome Canary"}
-	repeat with browser in browsers
-		return execute_javascript(browser, jquery, whatsapp, conversation_title, message)
-	end repeat
+  set browsers to {"Google Chrome", "Google Chrome Canary"}
+  repeat with browser in browsers
+    return execute_javascript(browser, jquery, whatsapp, conversation_title, message)
+  end repeat
 
 end run

--- a/whatsapp.scpt
+++ b/whatsapp.scpt
@@ -17,7 +17,8 @@ on execute_javascript(browser, jquery, whatsapp, conversation_title, message)
 						execute t javascript ("var message = \"" & message & "\";")
 						execute t javascript jquery
 						execute t javascript whatsapp
-						return
+                        set msgs to execute t javascript "msgs" 
+                        if msgs is not "" then return msgs
 					end if
 				end repeat
 			end repeat
@@ -49,6 +50,7 @@ on run(arguments)
 
 	set browsers to {"Google Chrome", "Google Chrome Canary"}
 	repeat with browser in browsers
-		execute_javascript(browser, jquery, whatsapp, conversation_title, message)
+		return execute_javascript(browser, jquery, whatsapp, conversation_title, message)
 	end repeat
+
 end run


### PR DESCRIPTION
Sometimes I am lazy and type partial names, resulting in unexpected message sent.

For example, if I am sending message to Mr. Last, and I also have a group named Ever Lasting Friendship, then `<script> Last "Hey something private!"` may turn out to be ugly.

Hence I'd do a `<script> Last` and if it has chosen the correct chat in Chrome, then I `<Up>` and type my message, otherwise I would do `<script> "Mr. Last"` to ensure it is correct.

But we are making this script just to avoid having to deal with the Chrome! So this feature comes..
`<script> Last` would show the latest 5 messages, so basically I don't have to look at my phone's Whatsapp nor the Chrome's -- I just have to have the Chrome opened but not in sight ;)

Please see if this change is good. Thank you for reading till here :D